### PR TITLE
Omit HTML props for `Label` component

### DIFF
--- a/components/base/input/input-group.tsx
+++ b/components/base/input/input-group.tsx
@@ -94,7 +94,7 @@ export const InputGroup = ({ size = "sm", prefix, leadingAddon, trailingAddon, l
         >
             {(state) => (
                 <>
-                    {label && <Label {...state}>{label}</Label>}
+                    {label && <Label isRequired={state.isRequired}>{label}</Label>}
 
                     <div
                         data-input-size={size}
@@ -121,7 +121,7 @@ export const InputGroup = ({ size = "sm", prefix, leadingAddon, trailingAddon, l
                         {trailingAddon && <section data-trailing={hasTrailing || undefined}>{trailingAddon}</section>}
                     </div>
 
-                    {hint && <HintText {...state}>{hint}</HintText>}
+                    {hint && <HintText isInvalid={state.isInvalid}>{hint}</HintText>}
                 </>
             )}
         </TextField>

--- a/components/base/input/input-payment.tsx
+++ b/components/base/input/input-payment.tsx
@@ -102,11 +102,18 @@ export const PaymentInput = ({ onChange, value, defaultValue, className, maxLeng
         >
             {({ isDisabled, isInvalid, isRequired }) => (
                 <>
-                    {label && <Label {...{ isRequired }}>{label}</Label>}
+                    {label && <Label isRequired={isRequired}>{label}</Label>}
 
-                    <InputBase {...props} {...{ isDisabled, isInvalid }} icon={card.icon} inputClassName="pl-13" iconClassName="left-2.5 h-6 w-8.5" />
+                    <InputBase
+                        {...props}
+                        isDisabled={isDisabled}
+                        isInvalid={isInvalid}
+                        icon={card.icon}
+                        inputClassName="pl-13"
+                        iconClassName="left-2.5 h-6 w-8.5"
+                    />
 
-                    {hint && <HintText {...{ isInvalid }}>{hint}</HintText>}
+                    {hint && <HintText isInvalid={isInvalid}>{hint}</HintText>}
                 </>
             )}
         </TextField>

--- a/components/base/textarea/textarea.tsx
+++ b/components/base/textarea/textarea.tsx
@@ -70,9 +70,13 @@ export const TextArea = ({
             value={value as string}
             defaultValue={defaultValue as string}
         >
-            {({ isInvalid }) => (
+            {({ isInvalid, isRequired }) => (
                 <>
-                    {label && <Label tooltip={tooltip}>{label}</Label>}
+                    {label && (
+                        <Label isRequired={isRequired} tooltip={tooltip}>
+                            {label}
+                        </Label>
+                    )}
 
                     <TextAreaBase {...textAreaProps} />
 


### PR DESCRIPTION
## Description

This PR fixes the React warning where the label element was receiving non-DOM props which was due to passing the whole `{...state}` of the `TextField` component.

Now the `Label` component receives only the props it needs.
