### PR TITLE
Inline textarea resize handle

### DIFF
--- a/components/base/textarea/textarea.tsx
+++ b/components/base/textarea/textarea.tsx
@@ -9,6 +9,11 @@ import { TextField } from "@/components/base/input/input";
 import { Label } from "@/components/base/input/label";
 import { cx } from "@/utils/cx";
 
+// Creates a data URL for an SVG resize handle with a given color.
+const getResizeHandleBg = (color: string) => {
+    return `url(data:image/svg+xml;base64,${btoa(`<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M10 2L2 10" stroke="${color}" stroke-linecap="round"/><path d="M11 7L7 11" stroke="${color}" stroke-linecap="round"/></svg>`)})`;
+};
+
 interface TextAreaBaseProps extends AriaTextAreaProps {
     ref?: Ref<HTMLTextAreaElement>;
 }
@@ -17,12 +22,18 @@ export const TextAreaBase = ({ className, ...props }: TextAreaBaseProps) => {
     return (
         <AriaTextArea
             {...props}
+            style={
+                {
+                    "--resize-handle-bg": getResizeHandleBg("#D5D7DA"),
+                    "--resize-handle-bg-dark": getResizeHandleBg("#373A41"),
+                } as React.CSSProperties
+            }
             className={(state) =>
                 cx(
                     "w-full scroll-py-3 rounded-lg bg-primary px-3.5 py-3 text-md text-primary shadow-xs ring-1 ring-primary transition duration-100 ease-linear ring-inset placeholder:text-placeholder autofill:rounded-lg autofill:text-primary focus:outline-hidden",
 
                     // Resize handle
-                    "[&::-webkit-resizer]:bg-[url(/base/textarea-resize-handle-light-mode.svg)] [&::-webkit-resizer]:bg-contain dark:[&::-webkit-resizer]:bg-[url(/base/textarea-resize-handle-dark-mode.svg)]",
+                    "[&::-webkit-resizer]:bg-(image:--resize-handle-bg) [&::-webkit-resizer]:bg-contain dark:[&::-webkit-resizer]:bg-(image:--resize-handle-bg-dark)",
 
                     state.isFocused && !state.isDisabled && "ring-2 ring-brand",
                     state.isDisabled && "cursor-not-allowed bg-disabled_subtle text-disabled ring-disabled",


### PR DESCRIPTION
## Description

This PR inlines the textarea resize handle instead of pointing to a remote image which made the component less independent and required a little more work to configure. Now the resize handle SVG is inlined into base 64 data URI.

## Related issues

https://github.com/untitleduico/react/issues/25