### PR TITLE
Refactor type definitions in `is-react-component.ts` for improved type safety

### DIFF
--- a/utils/is-react-component.ts
+++ b/utils/is-react-component.ts
@@ -1,31 +1,35 @@
 import type React from "react";
 
-type ReactComponent = React.FC<any> | React.ComponentClass<any, any>;
+type ReactComponent = React.FC<unknown> | React.ComponentClass<unknown, unknown>;
 
 /**
  * Checks if a given value is a function component.
  */
-export const isFunctionComponent = (component: any): component is React.FC<any> => {
+export const isFunctionComponent = (component: unknown): component is React.FC<unknown> => {
     return typeof component === "function";
 };
 
 /**
  * Checks if a given value is a class component.
  */
-export const isClassComponent = (component: any): component is React.ComponentClass<any, any> => {
+export const isClassComponent = (component: unknown): component is React.ComponentClass<unknown, unknown> => {
     return typeof component === "function" && component.prototype && (!!component.prototype.isReactComponent || !!component.prototype.render);
 };
 
 /**
  * Checks if a given value is a forward ref component.
  */
-export const isForwardRefComponent = (component: any): component is React.ForwardRefExoticComponent<any> => {
-    return typeof component === "object" && component !== null && component.$$typeof.toString() === "Symbol(react.forward_ref)";
+export const isForwardRefComponent = (component: unknown): component is React.ForwardRefExoticComponent<unknown> => {
+    return (
+        typeof component === "object" &&
+        component !== null &&
+        ((component as { $$typeof: unknown }).$$typeof as object).toString() === "Symbol(react.forward_ref)"
+    );
 };
 
 /**
  * Checks if a given value is a valid React component.
  */
-export const isReactComponent = (component: any): component is ReactComponent => {
+export const isReactComponent = (component: unknown): component is ReactComponent => {
     return isFunctionComponent(component) || isForwardRefComponent(component) || isClassComponent(component);
 };


### PR DESCRIPTION
## Description

Major change: replace `any` types with `unknown` for improved type safety.