### PR TITLE
Remove `asChild` prop from `TooltipTrigger`

### DIFF
--- a/components/application/app-navigation/base-components/nav-item-button.tsx
+++ b/components/application/app-navigation/base-components/nav-item-button.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import type { FC, MouseEventHandler } from "react";
-import { Tooltip, TooltipTrigger } from "@/components/base/tooltip/tooltip";
+import { Pressable } from "react-aria-components";
+import { Tooltip } from "@/components/base/tooltip/tooltip";
 import { cx } from "@/utils/cx";
 
 const styles = {
@@ -48,7 +49,7 @@ export const NavItemButton = ({
 }: NavItemButtonProps) => {
     return (
         <Tooltip title={label} placement={tooltipPlacement}>
-            <TooltipTrigger asChild>
+            <Pressable>
                 <a
                     href={href}
                     aria-label={label}
@@ -62,7 +63,7 @@ export const NavItemButton = ({
                 >
                     <Icon aria-hidden="true" className={cx("shrink-0 transition-inherit-all", styles[size].icon)} />
                 </a>
-            </TooltipTrigger>
+            </Pressable>
         </Tooltip>
     );
 };

--- a/components/base/tooltip/tooltip.tsx
+++ b/components/base/tooltip/tooltip.tsx
@@ -126,44 +126,12 @@ export const Tooltip = ({
     );
 };
 
-type TooltipTriggerProps =
-    | (AriaButtonProps &
-          RefAttributes<HTMLButtonElement> & {
-              /**
-               * If true, the tooltip trigger props will be passed down to the child element
-               * instead of wrapping the child element in a button.
-               */
-              asChild?: never;
-          })
-    | {
-          /**
-           * If true, the tooltip trigger props will be passed down to the child element
-           * instead of wrapping the child element in a button.
-           */
-          asChild: true;
-          isDisabled?: boolean;
-          children: Omit<DetailedReactHTMLElement<any, any>, "ref">;
-      };
+interface TooltipTriggerProps extends AriaButtonProps {}
 
-export const TooltipTrigger = (props: TooltipTriggerProps) => {
-    if (props.asChild) {
-        const triggerRef = useRef<FocusableElement>(null);
-
-        const { focusableProps } = useFocusable(
-            {
-                isDisabled: props.isDisabled,
-            },
-            triggerRef,
-        );
-
-        return cloneElement(props.children, mergeProps(focusableProps, props.children.props, { ref: triggerRef }));
-    }
-
-    const { asChild: _, className, ...buttonProps } = props;
-
+export const TooltipTrigger = ({ children, className, ...buttonProps }: TooltipTriggerProps) => {
     return (
         <AriaButton {...buttonProps} className={(values) => cx("h-max w-max outline-hidden", typeof className === "function" ? className(values) : className)}>
-            {props.children}
+            {children}
         </AriaButton>
     );
 };


### PR DESCRIPTION
## Description

This PR removes `asChild` prop from `TooltipTrigger` in favor of [simpler custom trigger API](https://react-spectrum.adobe.com/react-aria/Tooltip.html#custom-trigger) from React Aria. The old way of doing it with `asChild` was adding unnecessary complexity both in terms of types and functionality. 

**Before**

```tsx
import { Tooltip, TooltipTrigger } from "@/components/base/tooltip/tooltip";

<Tooltip title="This is a tooltip">
    <TooltipTrigger asChild>
        <a href="#">
            Link
        </a>
    </TooltipTrigger>
</Tooltip>
```

**After**

```tsx
import { Pressable } from "react-aria-components";
import { Tooltip } from "@/components/base/tooltip/tooltip";

<Tooltip title="This is a tooltip">
    <Pressable>
        <a href="#">
            Link
        </a>
    </Pressable>
</Tooltip>
```