### PR TITLE
Replace arbitrary pixels with space variables

### DIFF
--- a/components/application/app-navigation/base-components/nav-account-card.tsx
+++ b/components/application/app-navigation/base-components/nav-account-card.tsx
@@ -140,7 +140,7 @@ const NavAccountCardMenuItem = ({
                 </div>
 
                 {shortcut && (
-                    <kbd className="flex rounded px-1 py-[1px] font-body text-xs font-medium text-tertiary ring-1 ring-secondary ring-inset">{shortcut}</kbd>
+                    <kbd className="flex rounded px-1 py-px font-body text-xs font-medium text-tertiary ring-1 ring-secondary ring-inset">{shortcut}</kbd>
                 )}
             </div>
         </button>

--- a/components/application/charts/line-charts.demo.tsx
+++ b/components/application/charts/line-charts.demo.tsx
@@ -162,7 +162,7 @@ export const LineChart01 = () => {
 
                     <Area
                         isAnimationActive={false}
-                        className={cx(colors["A"], "[&_.recharts-area-area]:translate-y-[6px] [&_.recharts-area-area]:[clip-path:inset(0_0_6px_0)]")}
+                        className={cx(colors["A"], "[&_.recharts-area-area]:translate-y-1.5 [&_.recharts-area-area]:[clip-path:inset(0_0_6px_0)]")}
                         dataKey="A"
                         name="Series 1"
                         type="monotone"
@@ -177,7 +177,7 @@ export const LineChart01 = () => {
 
                     <Area
                         isAnimationActive={false}
-                        className={cx(colors["B"], "[&_.recharts-area-area]:translate-y-[6px] [&_.recharts-area-area]:[clip-path:inset(0_0_6px_0)]")}
+                        className={cx(colors["B"], "[&_.recharts-area-area]:translate-y-1.5 [&_.recharts-area-area]:[clip-path:inset(0_0_6px_0)]")}
                         dataKey="B"
                         name="Series 2"
                         type="monotone"
@@ -191,7 +191,7 @@ export const LineChart01 = () => {
 
                     <Area
                         isAnimationActive={false}
-                        className={cx(colors["C"], "[&_.recharts-area-area]:translate-y-[6px] [&_.recharts-area-area]:[clip-path:inset(0_0_6px_0)]")}
+                        className={cx(colors["C"], "[&_.recharts-area-area]:translate-y-1.5 [&_.recharts-area-area]:[clip-path:inset(0_0_6px_0)]")}
                         dataKey="C"
                         name="Series 3"
                         type="monotone"
@@ -290,7 +290,7 @@ export const LineChart02 = () => {
 
                     <Area
                         isAnimationActive={false}
-                        className={cx(colors["A"], "[&_.recharts-area-area]:translate-y-[6px] [&_.recharts-area-area]:[clip-path:inset(0_0_6px_0)]")}
+                        className={cx(colors["A"], "[&_.recharts-area-area]:translate-y-1.5 [&_.recharts-area-area]:[clip-path:inset(0_0_6px_0)]")}
                         dataKey="A"
                         name="Series 1"
                         type="monotone"
@@ -305,7 +305,7 @@ export const LineChart02 = () => {
 
                     <Area
                         isAnimationActive={false}
-                        className={cx(colors["B"], "[&_.recharts-area-area]:translate-y-[6px] [&_.recharts-area-area]:[clip-path:inset(0_0_6px_0)]")}
+                        className={cx(colors["B"], "[&_.recharts-area-area]:translate-y-1.5 [&_.recharts-area-area]:[clip-path:inset(0_0_6px_0)]")}
                         dataKey="B"
                         name="Series 2"
                         type="monotone"
@@ -321,7 +321,7 @@ export const LineChart02 = () => {
 
                     <Area
                         isAnimationActive={false}
-                        className={cx(colors["C"], "[&_.recharts-area-area]:translate-y-[6px] [&_.recharts-area-area]:[clip-path:inset(0_0_6px_0)]")}
+                        className={cx(colors["C"], "[&_.recharts-area-area]:translate-y-1.5 [&_.recharts-area-area]:[clip-path:inset(0_0_6px_0)]")}
                         dataKey="C"
                         name="Series 3"
                         type="monotone"
@@ -428,7 +428,7 @@ export const LineChart03 = () => {
 
                     <Area
                         isAnimationActive={false}
-                        className={cx(colors["A"], "[&_.recharts-area-area]:translate-y-[6px] [&_.recharts-area-area]:[clip-path:inset(0_0_6px_0)]")}
+                        className={cx(colors["A"], "[&_.recharts-area-area]:translate-y-1.5 [&_.recharts-area-area]:[clip-path:inset(0_0_6px_0)]")}
                         dataKey="A"
                         name="Series 1"
                         type="monotone"
@@ -443,7 +443,7 @@ export const LineChart03 = () => {
 
                     <Area
                         isAnimationActive={false}
-                        className={cx(colors["B"], "[&_.recharts-area-area]:translate-y-[6px] [&_.recharts-area-area]:[clip-path:inset(0_0_6px_0)]")}
+                        className={cx(colors["B"], "[&_.recharts-area-area]:translate-y-1.5 [&_.recharts-area-area]:[clip-path:inset(0_0_6px_0)]")}
                         dataKey="B"
                         name="Series 2"
                         type="monotone"
@@ -457,7 +457,7 @@ export const LineChart03 = () => {
 
                     <Area
                         isAnimationActive={false}
-                        className={cx(colors["C"], "[&_.recharts-area-area]:translate-y-[6px] [&_.recharts-area-area]:[clip-path:inset(0_0_6px_0)]")}
+                        className={cx(colors["C"], "[&_.recharts-area-area]:translate-y-1.5 [&_.recharts-area-area]:[clip-path:inset(0_0_6px_0)]")}
                         dataKey="C"
                         name="Series 3"
                         type="monotone"
@@ -557,7 +557,7 @@ export const LineChart04 = () => {
 
                     <Area
                         isAnimationActive={false}
-                        className={cx(colors["A"], "[&_.recharts-area-area]:translate-y-[6px] [&_.recharts-area-area]:[clip-path:inset(0_0_6px_0)]")}
+                        className={cx(colors["A"], "[&_.recharts-area-area]:translate-y-1.5 [&_.recharts-area-area]:[clip-path:inset(0_0_6px_0)]")}
                         dataKey="A"
                         name="Series 1"
                         type="monotone"
@@ -572,7 +572,7 @@ export const LineChart04 = () => {
 
                     <Area
                         isAnimationActive={false}
-                        className={cx(colors["B"], "[&_.recharts-area-area]:translate-y-[6px] [&_.recharts-area-area]:[clip-path:inset(0_0_6px_0)]")}
+                        className={cx(colors["B"], "[&_.recharts-area-area]:translate-y-1.5 [&_.recharts-area-area]:[clip-path:inset(0_0_6px_0)]")}
                         dataKey="B"
                         name="Series 2"
                         type="monotone"
@@ -586,7 +586,7 @@ export const LineChart04 = () => {
 
                     <Area
                         isAnimationActive={false}
-                        className={cx(colors["C"], "[&_.recharts-area-area]:translate-y-[6px] [&_.recharts-area-area]:[clip-path:inset(0_0_6px_0)]")}
+                        className={cx(colors["C"], "[&_.recharts-area-area]:translate-y-1.5 [&_.recharts-area-area]:[clip-path:inset(0_0_6px_0)]")}
                         dataKey="C"
                         name="Series 3"
                         type="monotone"

--- a/components/application/date-picker/cell.tsx
+++ b/components/application/date-picker/cell.tsx
@@ -93,7 +93,7 @@ export const CalendarCell = ({ date, isHighlighted, ...props }: CalendarCellProp
                         {(isHighlighted || isTodayDate) && (
                             <div
                                 className={cx(
-                                    "absolute bottom-1 left-1/2 size-[5px] -translate-x-1/2 rounded-full",
+                                    "absolute bottom-1 left-1/2 size-1.25 -translate-x-1/2 rounded-full",
                                     isDisabled ? "bg-fg-disabled" : markedAsSelected ? "bg-fg-white" : "bg-fg-brand-primary",
                                 )}
                             />

--- a/components/application/date-picker/date-picker.demo.tsx
+++ b/components/application/date-picker/date-picker.demo.tsx
@@ -165,7 +165,7 @@ export const DarkModeDemo = () => {
     const [focusedValue, setFocusedValue] = useState<DateValue | null>(now);
 
     return (
-        <div className="relative h-[720px] w-full max-w-[720px] [--clip-boundary:50%]">
+        <div className="relative h-180 w-full max-w-180 [--clip-boundary:50%]">
             <div
                 style={{
                     clipPath: "polygon(0 0, var(--clip-boundary) 0, var(--clip-boundary) 100%, 0 100%)",

--- a/components/base/badges/badges.tsx
+++ b/components/base/badges/badges.tsx
@@ -259,7 +259,7 @@ export const BadgeWithFlag = <T extends BadgeTypes>(props: BadgeWithFlagProps<T>
     const colors = withPillTypes[type];
 
     const pillSizes = {
-        sm: "gap-1 py-0.5 pl-[3px] pr-2 text-xs font-medium",
+        sm: "gap-1 py-0.5 pl-0.75 pr-2 text-xs font-medium",
         md: "gap-1.5 py-0.5 pl-1 pr-2.5 text-sm font-medium",
         lg: "gap-1.5 py-1 pl-1.5 pr-3 text-sm font-medium",
     };
@@ -297,7 +297,7 @@ export const BadgeWithImage = <T extends BadgeTypes>(props: BadgeWithImageProps<
     const colors = withPillTypes[type];
 
     const pillSizes = {
-        sm: "gap-1 py-0.5 pl-[3px] pr-2 text-xs font-medium",
+        sm: "gap-1 py-0.5 pl-0.75 pr-2 text-xs font-medium",
         md: "gap-1.5 py-0.5 pl-1 pr-2.5 text-sm font-medium",
         lg: "gap-1.5 py-1 pl-1.5 pr-3 text-sm font-medium",
     };
@@ -343,12 +343,12 @@ export const BadgeWithButton = <T extends BadgeTypes>(props: BadgeWithButtonProp
     const colors = withPillTypes[type];
 
     const pillSizes = {
-        sm: "gap-0.5 py-0.5 pl-2 pr-[3px] text-xs font-medium",
+        sm: "gap-0.5 py-0.5 pl-2 pr-0.75 text-xs font-medium",
         md: "gap-0.5 py-0.5 pl-2.5 pr-1 text-sm font-medium",
         lg: "gap-0.5 py-1 pl-3 pr-1.5 text-sm font-medium",
     };
     const badgeSizes = {
-        sm: "gap-0.5 py-0.5 pl-1.5 pr-[3px] text-xs font-medium",
+        sm: "gap-0.5 py-0.5 pl-1.5 pr-0.75 text-xs font-medium",
         md: "gap-0.5 py-0.5 pl-2 pr-1 text-sm font-medium",
         lg: "gap-0.5 py-1 pl-2.5 pr-1.5 text-sm font-medium rounded-lg",
     };
@@ -392,13 +392,13 @@ export const BadgeIcon = <T extends BadgeTypes>(props: BadgeIconProps<T>) => {
     const colors = withPillTypes[type];
 
     const pillSizes = {
-        sm: "p-[5px]",
+        sm: "p-1.25",
         md: "p-1.5",
         lg: "p-2",
     };
 
     const badgeSizes = {
-        sm: "p-[5px]",
+        sm: "p-1.25",
         md: "p-1.5",
         lg: "p-2 rounded-lg",
     };

--- a/components/base/button-group/button-group.demo.tsx
+++ b/components/base/button-group/button-group.demo.tsx
@@ -30,13 +30,13 @@ export const LeadingIcon = () => (
 
 export const ButtonGroupDot = () => (
     <ButtonGroup selectedKeys={["archive"]}>
-        <ButtonGroupItem id="archive" iconLeading={<Dot className="mx-[3px] size-2 text-fg-success-secondary in-disabled:text-fg-disabled_subtle" />}>
+        <ButtonGroupItem id="archive" iconLeading={<Dot className="mx-0.75 size-2 text-fg-success-secondary in-disabled:text-fg-disabled_subtle" />}>
             Text
         </ButtonGroupItem>
-        <ButtonGroupItem id="edit" iconLeading={<Dot className="mx-[3px] size-2 text-fg-success-secondary in-disabled:text-fg-disabled_subtle" />}>
+        <ButtonGroupItem id="edit" iconLeading={<Dot className="mx-0.75 size-2 text-fg-success-secondary in-disabled:text-fg-disabled_subtle" />}>
             Text
         </ButtonGroupItem>
-        <ButtonGroupItem id="delete" isDisabled iconLeading={<Dot className="mx-[3px] size-2 text-fg-success-secondary in-disabled:text-fg-disabled_subtle" />}>
+        <ButtonGroupItem id="delete" isDisabled iconLeading={<Dot className="mx-0.75 size-2 text-fg-success-secondary in-disabled:text-fg-disabled_subtle" />}>
             Text
         </ButtonGroupItem>
     </ButtonGroup>
@@ -107,16 +107,16 @@ export const All = () => (
         </ButtonGroup>
 
         <ButtonGroup selectedKeys={["archive"]}>
-            <ButtonGroupItem id="archive" iconLeading={<Dot className="mx-[3px] size-2 text-fg-success-secondary in-disabled:text-fg-disabled_subtle" />}>
+            <ButtonGroupItem id="archive" iconLeading={<Dot className="mx-0.75 size-2 text-fg-success-secondary in-disabled:text-fg-disabled_subtle" />}>
                 Archive
             </ButtonGroupItem>
-            <ButtonGroupItem id="edit" iconLeading={<Dot className="mx-[3px] size-2 text-fg-success-secondary in-disabled:text-fg-disabled_subtle" />}>
+            <ButtonGroupItem id="edit" iconLeading={<Dot className="mx-0.75 size-2 text-fg-success-secondary in-disabled:text-fg-disabled_subtle" />}>
                 Edit
             </ButtonGroupItem>
             <ButtonGroupItem
                 id="delete"
                 isDisabled
-                iconLeading={<Dot className="mx-[3px] size-2 text-fg-success-secondary in-disabled:text-fg-disabled_subtle" />}
+                iconLeading={<Dot className="mx-0.75 size-2 text-fg-success-secondary in-disabled:text-fg-disabled_subtle" />}
             >
                 Delete
             </ButtonGroupItem>

--- a/components/base/select/combobox.tsx
+++ b/components/base/select/combobox.tsx
@@ -59,7 +59,7 @@ const ComboBoxValue = ({ size, shortcut, placeholder, shortcutClassName, ...othe
                         {inputValue && (
                             <span className="absolute top-1/2 z-0 inline-flex w-full -translate-y-1/2 gap-2 truncate" aria-hidden="true">
                                 <p className={cx("text-md font-medium text-primary", isDisabled && "text-disabled")}>{first}</p>
-                                {last && <p className={cx("-ml-[3px] text-md text-tertiary", isDisabled && "text-disabled")}>{last}</p>}
+                                {last && <p className={cx("-ml-0.75 text-md text-tertiary", isDisabled && "text-disabled")}>{last}</p>}
                             </span>
                         )}
 

--- a/components/base/select/multi-select.tsx
+++ b/components/base/select/multi-select.tsx
@@ -266,15 +266,15 @@ const InnerMultiSelect = ({ isDisabled, shortcut, shortcutClassName, placeholder
         <div className="relative flex w-full flex-1 flex-row flex-wrap items-center justify-start gap-1.5">
             {!isSelectionEmpty &&
                 selectContext?.selectedItems?.items?.map((value) => (
-                    <span key={value.id} className="flex items-center rounded-md bg-primary py-0.5 pr-1 pl-[5px] ring-1 ring-primary ring-inset">
+                    <span key={value.id} className="flex items-center rounded-md bg-primary py-0.5 pr-1 pl-1.25 ring-1 ring-primary ring-inset">
                         <Avatar size="xxs" alt={value?.label} src={value?.avatarUrl} />
 
-                        <p className="ml-[5px] truncate text-sm font-medium whitespace-nowrap text-secondary select-none">{value?.label}</p>
+                        <p className="ml-1.25 truncate text-sm font-medium whitespace-nowrap text-secondary select-none">{value?.label}</p>
 
                         <TagCloseX
                             size="md"
                             isDisabled={isDisabled}
-                            className="ml-[3px]"
+                            className="ml-0.75"
                             // For workaround, onKeyDown is added to the button
                             onKeyDown={(event) => handleTagKeyDown(event, value.id)}
                             onPress={() => selectContext.onRemove(new Set([value.id]))}

--- a/components/base/tags/base-components/tag-close-x.tsx
+++ b/components/base/tags/base-components/tag-close-x.tsx
@@ -13,7 +13,7 @@ interface TagCloseXProps extends AriaButtonProps, RefAttributes<HTMLButtonElemen
 const styles = {
     sm: { root: "p-0.5", icon: "size-2.5" },
     md: { root: "p-0.5", icon: "size-3" },
-    lg: { root: "p-[3px]", icon: "size-3.5" },
+    lg: { root: "p-0.75", icon: "size-3.5" },
 };
 
 export const TagCloseX = ({ size = "md", className, ...otherProps }: TagCloseXProps) => {

--- a/components/base/tags/tags.tsx
+++ b/components/base/tags/tags.tsx
@@ -54,8 +54,8 @@ export const TagList = AriaTagList;
 const styles = {
     sm: {
         root: {
-            base: "px-2 py-[3px] text-xs font-medium",
-            withCheckbox: "pl-[5px]",
+            base: "px-2 py-0.75 text-xs font-medium",
+            withCheckbox: "pl-1.25",
             withAvatar: "pl-1",
             withDot: "pl-1.5",
             withCount: "pr-1",
@@ -66,22 +66,22 @@ const styles = {
     },
     md: {
         root: {
-            base: "px-[9px] py-0.5 text-sm font-medium",
+            base: "px-2.25 py-0.5 text-sm font-medium",
             withCheckbox: "pl-1",
-            withAvatar: "pl-[5px]",
-            withDot: "pl-[7px]",
-            withCount: "pr-[3px]",
+            withAvatar: "pl-1.25",
+            withDot: "pl-1.75",
+            withCount: "pr-0.75",
             withClose: "pr-1",
         },
-        content: "gap-[5px]",
-        count: "px-[5px] text-xs font-medium",
+        content: "gap-1.25",
+        count: "px-1.25 text-xs font-medium",
     },
     lg: {
         root: {
             base: "px-2.5 py-1 text-sm font-medium",
-            withCheckbox: "pl-[5px]",
-            withAvatar: "pl-[7px]",
-            withDot: "pl-[9px]",
+            withCheckbox: "pl-1.25",
+            withAvatar: "pl-1.75",
+            withDot: "pl-2.25",
             withCount: "pr-1",
             withClose: "pr-1",
         },
@@ -119,7 +119,7 @@ export const Tag = ({
             textValue={typeof children === "string" ? children : undefined}
             className={(state) =>
                 cx(
-                    "flex cursor-default items-center gap-[3px] rounded-md bg-primary text-secondary ring-1 ring-primary ring-inset focus:outline-hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus-ring",
+                    "flex cursor-default items-center gap-0.75 rounded-md bg-primary text-secondary ring-1 ring-primary ring-inset focus:outline-hidden focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus-ring",
                     styles[context.size].root.base,
 
                     // With avatar

--- a/components/shared-assets/illustrations/box.tsx
+++ b/components/shared-assets/illustrations/box.tsx
@@ -24,7 +24,7 @@ export const sm = ({
     ...otherProps
 }: Omit<IllustrationProps, "size">) => {
     return (
-        <div {...otherProps} className={cx("relative h-[126px] w-[152px]", className)}>
+        <div {...otherProps} className={cx("relative h-31.5 w-38", className)}>
             <svg viewBox="0 0 152 126" fill="none" className={cx("size-full stroke-inherit text-inherit", svgClassName)}>
                 <circle cx="76" cy="60" r="52" className="fill-utility-gray-100" />
                 <circle cx="21" cy="27" r="5" className="fill-utility-gray-100" />
@@ -105,7 +105,7 @@ export const md = ({
     ...otherProps
 }: Omit<IllustrationProps, "size">) => {
     return (
-        <div {...otherProps} className={cx("relative h-[148px] w-[172px]", className)}>
+        <div {...otherProps} className={cx("relative h-37 w-43", className)}>
             <svg viewBox="0 0 172 148" fill="none" className={cx("size-full stroke-inherit text-inherit", svgClassName)}>
                 <circle cx="86" cy="74" r="64" className="fill-utility-gray-100" />
                 <circle cx="20" cy="30" r="6" className="fill-utility-gray-100" />
@@ -186,7 +186,7 @@ export const lg = ({
     ...otherProps
 }: Omit<IllustrationProps, "size">) => {
     return (
-        <div {...otherProps} className={cx("relative h-[181px] w-[220px]", className)}>
+        <div {...otherProps} className={cx("relative h-45.25 w-55", className)}>
             <svg viewBox="0 0 220 181" fill="none" className={cx("size-full stroke-inherit text-inherit", svgClassName)}>
                 <circle cx="110" cy="90" r="80" className="fill-utility-gray-100" />
                 <circle cx="26" cy="30" r="8" className="fill-utility-gray-100" />

--- a/components/shared-assets/illustrations/cloud.tsx
+++ b/components/shared-assets/illustrations/cloud.tsx
@@ -24,7 +24,7 @@ export const sm = ({
     ...otherProps
 }: Omit<IllustrationProps, "size">) => {
     return (
-        <div {...otherProps} className={cx("relative h-[120px] w-[152px]", className)}>
+        <div {...otherProps} className={cx("relative h-30 w-38", className)}>
             <svg viewBox="0 0 152 120" fill="none" className={cx("size-full stroke-inherit text-inherit", svgClassName)}>
                 <circle cx="76" cy="52" r="52" className="fill-utility-gray-100" />
 
@@ -107,7 +107,7 @@ export const md = ({
     ...otherProps
 }: Omit<IllustrationProps, "size">) => {
     return (
-        <div {...otherProps} className={cx("relative h-[128px] w-[172px]", className)}>
+        <div {...otherProps} className={cx("relative h-32 w-43", className)}>
             <svg viewBox="0 0 182 137" fill="none" className={cx("size-full stroke-inherit text-inherit", svgClassName)}>
                 <circle cx="91" cy="64" r="64" className="fill-utility-gray-100" />
 
@@ -191,7 +191,7 @@ export const lg = ({
     ...otherProps
 }: Omit<IllustrationProps, "size">) => {
     return (
-        <div {...otherProps} className={cx("relative h-[160px] w-[220px]", className)}>
+        <div {...otherProps} className={cx("relative h-40 w-55", className)}>
             <svg viewBox="0 0 220 160" fill="none" className={cx("size-full stroke-inherit text-inherit", svgClassName)}>
                 <circle cx="110" cy="80" r="80" className="fill-utility-gray-100" />
                 <circle cx="26" cy="20" r="8" className="fill-utility-gray-100" />

--- a/components/shared-assets/illustrations/credit-card.tsx
+++ b/components/shared-assets/illustrations/credit-card.tsx
@@ -24,7 +24,7 @@ export const sm = ({
     ...otherProps
 }: Omit<IllustrationProps, "size">) => {
     return (
-        <div {...otherProps} className={cx("relative h-[118px] w-[152px]", className)}>
+        <div {...otherProps} className={cx("relative h-29.5 w-38", className)}>
             <svg viewBox="0 0 152 118" fill="none" className={cx("size-full stroke-inherit text-inherit", svgClassName)}>
                 <circle cx="21" cy="5" r="5" className="fill-utility-gray-100" />
                 <circle cx="18" cy="109" r="7" className="fill-utility-gray-100" />
@@ -119,7 +119,7 @@ export const md = ({
     ...otherProps
 }: Omit<IllustrationProps, "size">) => {
     return (
-        <div {...otherProps} className={cx("relative h-[143px] w-[180px]", className)}>
+        <div {...otherProps} className={cx("relative h-35.75 w-45", className)}>
             <svg viewBox="0 0 180 143" fill="none" className={cx("size-full stroke-inherit text-inherit", svgClassName)}>
                 <circle cx="90" cy="64" r="64" className="fill-utility-gray-100" />
                 <circle cx="24" cy="6" r="6" className="fill-utility-gray-100" />
@@ -212,7 +212,7 @@ export const lg = ({
     ...otherProps
 }: Omit<IllustrationProps, "size">) => {
     return (
-        <div {...otherProps} className={cx("relative h-[167px] w-[220px]", className)}>
+        <div {...otherProps} className={cx("relative h-41.75 w-55", className)}>
             <svg viewBox="0 0 220 167" fill="none" className={cx("size-full stroke-inherit text-inherit", svgClassName)}>
                 <circle cx="110" cy="80" r="80" className="fill-utility-gray-100" />
                 <circle cx="18" cy="12" r="8" className="fill-utility-gray-100" />

--- a/components/shared-assets/illustrations/documents.tsx
+++ b/components/shared-assets/illustrations/documents.tsx
@@ -24,7 +24,7 @@ export const sm = ({
     ...otherProps
 }: Omit<IllustrationProps, "size">) => {
     return (
-        <div {...otherProps} className={cx("relative h-[120px] w-[161px]", className)}>
+        <div {...otherProps} className={cx("relative h-30 w-40.25", className)}>
             <svg viewBox="0 0 161 120" fill="none" className={cx("size-full stroke-inherit text-inherit", svgClassName)}>
                 <circle cx="27" cy="11" r="5" className="fill-utility-gray-100" />
                 <circle cx="24" cy="109" r="7" className="fill-utility-gray-100" />
@@ -191,7 +191,7 @@ export const md = ({
     ...otherProps
 }: Omit<IllustrationProps, "size">) => {
     return (
-        <div {...otherProps} className={cx("relative h-[137px] w-[185px]", className)}>
+        <div {...otherProps} className={cx("relative h-34.25 w-46.25", className)}>
             <svg viewBox="0 0 185 137" fill="none" className={cx("size-full stroke-inherit text-inherit", svgClassName)}>
                 <circle cx="95" cy="64" r="64" className="fill-utility-gray-100" />
                 <circle cx="29" cy="12" r="6" className="fill-utility-gray-100" />
@@ -363,7 +363,7 @@ export const lg = ({
     ...otherProps
 }: Omit<IllustrationProps, "size">) => {
     return (
-        <div {...otherProps} className={cx("relative h-[166px] w-[230px]", className)}>
+        <div {...otherProps} className={cx("relative h-41.5 w-57.5", className)}>
             <svg viewBox="0 0 230 166" fill="none" className={cx("size-full stroke-inherit text-inherit", svgClassName)}>
                 <circle cx="118" cy="80" r="80" className="fill-utility-gray-100" />
                 <circle cx="34" cy="20" r="8" className="fill-utility-gray-100" />


### PR DESCRIPTION
## Description

This PR replaced the arbitrary pixels (`px-[5px]`) in Tailwind CSS classes with arbitrary tokens (`px-1.25`).