### PR TITLE
Fix Type Check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ build/
 dist/
 .next/
 storybook-static/
+tsconfig.tsbuildinfo
 
 # Development
 .env

--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "motion": "^12.23.5",
         "next": "^15.3.5",
         "next-themes": "^0.4.6",
+        "qr-code-styling": "^1.9.2",
         "react": "^19.1.0",
         "react-aria": "^3.41.1",
         "react-aria-components": "^1.10.1",
@@ -1875,6 +1876,10 @@
     "public-encrypt": ["public-encrypt@4.0.3", "", { "dependencies": { "bn.js": "^4.1.0", "browserify-rsa": "^4.0.0", "create-hash": "^1.1.0", "parse-asn1": "^5.0.0", "randombytes": "^2.0.1", "safe-buffer": "^5.1.2" } }, "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "qr-code-styling": ["qr-code-styling@1.9.2", "", { "dependencies": { "qrcode-generator": "^1.4.4" } }, "sha512-RgJaZJ1/RrXJ6N0j7a+pdw3zMBmzZU4VN2dtAZf8ZggCfRB5stEQ3IoDNGaNhYY3nnZKYlYSLl5YkfWN5dPutg=="],
+
+    "qrcode-generator": ["qrcode-generator@1.5.2", "", {}, "sha512-pItrW0Z9HnDBnFmgiNrY1uxRdri32Uh9EjNYLPVC2zZ3ZRIIEqBoDgm4DkvDwNNDHTK7FNkmr8zAa77BYc9xNw=="],
 
     "qs": ["qs@6.14.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w=="],
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "motion": "^12.23.5",
     "next": "^15.3.5",
     "next-themes": "^0.4.6",
+    "qr-code-styling": "^1.9.2",
     "react": "^19.1.0",
     "react-aria": "^3.41.1",
     "react-aria-components": "^1.10.1",


### PR DESCRIPTION
## Description

- Ignore `tsconfig.tsbuildinfo` generated upon running `bud type-check`
- Fix `bud type-check` error below

```
$ tsc --noEmit
components/shared-assets/qr-code.tsx:5:69 - error TS2307: Cannot find module 'qr-code-styling' or its corresponding type declarations.

5 import QRCodeStyling, { type Options as QRCodeStylingOptions } from "qr-code-styling";
                                                                      ~~~~~~~~~~~~~~~~~
Found 1 error in components/shared-assets/qr-code.tsx:5
```

## Related issues

Let me know if it's better to create issues first for such non-component related PRs

### Manual testing steps

1. Clone repository or delete existing `node_modules`
2. Run `bun i`
3. Run `bun type-check`
