### PR TITLE
Add `collapse-start` and `collapse-end` to an array `activity-gauge`

### DIFF
--- a/components/application/charts/activity-gauges.demo.tsx
+++ b/components/application/charts/activity-gauges.demo.tsx
@@ -5,6 +5,7 @@ import { ChartLegendContent, ChartTooltipContent } from "@/components/applicatio
 import { cx } from "@/utils/cx";
 
 const radialData = [
+    // collapse-start
     {
         name: "Series 3",
         value: 660,
@@ -20,6 +21,7 @@ const radialData = [
         value: 866,
         className: "text-utility-brand-700",
     },
+    // collapse-end
 ];
 
 const sizes = {


### PR DESCRIPTION
## Description

Added missing `collapse-start` and `collapse-end` to an array inside `acitivity-gauge.demo.tsx` file

## Related issues

<!-- Link to any related issues -->

Closes #<!-- issue number -->

## Type of change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Style/UI change (visual improvements, no functional changes)
- [ ] Accessibility improvement
- [ ] Refactoring (code changes that neither fix a bug nor add a feature)
- [ ] Performance improvement
- [ ] Chore (dependency updates, tooling changes, etc.)


## Code quality checklist

- [x] **Code style**: Follows project conventions
- [x] **ESLint**: No linting errors
- [x] **Prettier**: Code is properly formatted
- [x] **TypeScript**: Full type coverage
- [x] **Imports**: Uses correct import paths (`@/components/...`)
- [x] **Performance**: No unnecessary re-renders or heavy computations
- [x] **Error handling**: Appropriate error boundaries and validation

## 📚 Documentation

<!-- Mark what documentation has been added/updated -->

- [ ] Component props are documented with TypeScript interfaces
- [ ] Storybook stories cover all variants
- [ ] Usage examples are provided

