### PR TITLE
Omit `onClick` from table row extended type

### DIFF
--- a/components/application/table/table.tsx
+++ b/components/application/table/table.tsx
@@ -210,7 +210,9 @@ const TableHead = ({ className, tooltip, label, children, ...props }: TableHeadP
 };
 TableHead.displayName = "TableHead";
 
-interface TableRowProps<T extends object> extends AriaRowProps<T>, Omit<ComponentPropsWithRef<"tr">, "children" | "className" | "slot" | "style" | "id"> {
+interface TableRowProps<T extends object>
+    extends AriaRowProps<T>,
+        Omit<ComponentPropsWithRef<"tr">, "children" | "className" | "onClick" | "slot" | "style" | "id"> {
     highlightSelectedRow?: boolean;
 }
 


### PR DESCRIPTION
## Description

This PR omits the `onClick` prop from `ComponentPropsWithRef<"tr">` when extending it for the table row props interface as it's not matching the `AriaRowProps`'s `onClick` prop anymore.

## Related issues

Closes #62

## Type of change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Style/UI change (visual improvements, no functional changes)
- [ ] Accessibility improvement
- [ ] Refactoring (code changes that neither fix a bug nor add a feature)
- [ ] Performance improvement
- [ ] Chore (dependency updates, tooling changes, etc.)

## Breaking changes

No breaking change

