### PR TITLE
FIx table sort icon direction

### DIFF
--- a/components/application/table/table.tsx
+++ b/components/application/table/table.tsx
@@ -199,7 +199,7 @@ const TableHead = ({ className, tooltip, label, children, ...props }: TableHeadP
 
                     {state.allowsSorting &&
                         (state.sortDirection ? (
-                            <ArrowDown className={cx("size-3 stroke-[3px] text-fg-quaternary", state.sortDirection === "descending" && "rotate-180")} />
+                            <ArrowDown className={cx("size-3 stroke-[3px] text-fg-quaternary", state.sortDirection === "ascending" && "rotate-180")} />
                         ) : (
                             <ChevronSelectorVertical size={12} strokeWidth={3} className="text-fg-quaternary" />
                         ))}


### PR DESCRIPTION
## Description

This PR fixes the direction of the table sort icon. Because, the sorting arrow icon was accidentally reversed (i.e. facing up for descending, facing down for ascending). Now it's fixed.

## Type of change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Style/UI change (visual improvements, no functional changes)
- [ ] Accessibility improvement
- [ ] Refactoring (code changes that neither fix a bug nor add a feature)
- [ ] Performance improvement
- [ ] Chore (dependency updates, tooling changes, etc.)
