### PR TITLE
Fix border-radius scale

### DIFF
--- a/components/application/app-navigation/header-navigation.tsx
+++ b/components/application/app-navigation/header-navigation.tsx
@@ -106,7 +106,7 @@ export const HeaderNavigationBase = ({
                             <a
                                 aria-label="Go to homepage"
                                 href="/"
-                                className="rounded-sm outline-focus-ring focus-visible:outline-2 focus-visible:outline-offset-2"
+                                className="rounded-xs outline-focus-ring focus-visible:outline-2 focus-visible:outline-offset-2"
                             >
                                 <UntitledLogo className="h-8" />
                             </a>

--- a/components/application/file-upload/draggable.tsx
+++ b/components/application/file-upload/draggable.tsx
@@ -139,8 +139,8 @@ export function Draggable({ name, type, size, fileIconType, theme }: DraggablePr
             <div className="rounded-md p-1.5 group-focus/drag:bg-tertiary group-focus/drag:ring-[0.5px] group-focus/drag:ring-black/5 group-focus/drag:ring-inset">
                 <FileIcon type={fileIconType || type} variant={theme} className="pointer-events-none size-10" />
             </div>
-            <p className="line-clamp-2 block max-w-50 rounded-xs text-center text-sm font-medium text-ellipsis text-primary">
-                <span className="rounded-xs box-decoration-clone px-[3.5px] py-[0.5px] group-focus/drag:bg-brand-700 group-focus/drag:text-white group-focus/drag:ring-[0.5px] group-focus/drag:ring-black/10 group-focus/drag:ring-inset">
+            <p className="line-clamp-2 block max-w-50 rounded text-center text-sm font-medium text-ellipsis text-primary">
+                <span className="rounded box-decoration-clone px-[3.5px] py-[0.5px] group-focus/drag:bg-brand-700 group-focus/drag:text-white group-focus/drag:ring-[0.5px] group-focus/drag:ring-black/10 group-focus/drag:ring-inset">
                     {name}
                 </span>
             </p>

--- a/components/application/table/table.demo.tsx
+++ b/components/application/table/table.demo.tsx
@@ -1015,7 +1015,7 @@ export const TableSomethingWentWrong = () => {
                             We had some trouble loading this page. Please refresh the page or{" "}
                             <a
                                 href="#"
-                                className="rounded-sm underline underline-offset-2 outline-focus-ring focus-visible:outline-2 focus-visible:outline-offset-2"
+                                className="rounded-xs underline underline-offset-2 outline-focus-ring focus-visible:outline-2 focus-visible:outline-offset-2"
                             >
                                 get in touch
                             </a>{" "}

--- a/components/base/buttons/button.tsx
+++ b/components/base/buttons/button.tsx
@@ -77,7 +77,7 @@ export const styles = sortCx({
         },
         "link-gray": {
             root: [
-                "justify-normal rounded-xs p-0! text-tertiary hover:text-tertiary_hover",
+                "justify-normal rounded p-0! text-tertiary hover:text-tertiary_hover",
                 // Inner text underline
                 "*:data-text:underline *:data-text:decoration-transparent *:data-text:underline-offset-2 hover:*:data-text:decoration-current",
                 // Icon styles
@@ -86,7 +86,7 @@ export const styles = sortCx({
         },
         "link-color": {
             root: [
-                "justify-normal rounded-xs p-0! text-brand-secondary hover:text-brand-secondary_hover",
+                "justify-normal rounded p-0! text-brand-secondary hover:text-brand-secondary_hover",
                 // Inner text underline
                 "*:data-text:underline *:data-text:decoration-transparent *:data-text:underline-offset-2 hover:*:data-text:decoration-current",
                 // Icon styles
@@ -122,7 +122,7 @@ export const styles = sortCx({
         },
         "link-destructive": {
             root: [
-                "justify-normal rounded-xs p-0! text-error-primary outline-error hover:text-error-primary_hover",
+                "justify-normal rounded p-0! text-error-primary outline-error hover:text-error-primary_hover",
                 // Inner text underline
                 "*:data-text:underline *:data-text:decoration-transparent *:data-text:underline-offset-2 hover:*:data-text:decoration-current",
                 // Icon styles

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -52,8 +52,8 @@
 
     /* RADIUS */
     --radius-none: 0px;
-    --radius-xs: 0.25rem;
-    --radius-sm: 0.125rem;
+    --radius-xs: 0.125rem;
+    --radius-sm: 0.25rem;
     --radius-DEFAULT: 0.25rem;
     --radius-md: 0.375rem;
     --radius-lg: 0.5rem;


### PR DESCRIPTION
## Description

This PR fixes a bug where border-radius variables didn't scale incrementally. Specifically, `--radius-xs` and `--radius-sm` were swapped before. Now they have their correct values.

## Related issues

<!-- Link to any related issues -->

Closes #70

## Type of change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Style/UI change (visual improvements, no functional changes)
- [ ] Accessibility improvement
- [ ] Refactoring (code changes that neither fix a bug nor add a feature)
- [ ] Performance improvement
- [ ] Chore (dependency updates, tooling changes, etc.)

## Breaking changes

<!-- If this includes breaking changes, describe them and provide migration guidance -->

### Migration guide

```tsx
// Before
className="rounded-xs"
className="rounded-sm"

// After
className="rounded-sm"
className="rounded"
```

## Additional context

<!-- Add any additional context, concerns, or questions -->
