### PR TITLE
fix: update `activity gauge` legend's item sorter

### DIFF
--- a/components/application/charts/activity-gauges.demo.tsx
+++ b/components/application/charts/activity-gauges.demo.tsx
@@ -101,7 +101,7 @@ export const ActivityGauge = ({ size = "sm", title = "1,000", subtitle = "Active
             >
                 <PolarAngleAxis tick={false} domain={[0, 1000]} type="number" reversed />
 
-                <Legend verticalAlign="bottom" align="center" layout="horizontal" content={<ChartLegendContent reversed />} />
+                <Legend itemSorter="dataKey" verticalAlign="bottom" align="center" layout="horizontal" content={<ChartLegendContent reversed />} />
 
                 <Tooltip content={<ChartTooltipContent isRadialChart />} />
 


### PR DESCRIPTION
## Description

Activity Gauge legend is sorting items alphabetically, to avoid this pas `itemSorter` prop to `dataKey`

## Type of change

<!-- Mark the relevant option with an "x" -->

- [*] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [*] Style/UI change (visual improvements, no functional changes)
- [ ] Accessibility improvement
- [ ] Refactoring (code changes that neither fix a bug nor add a feature)
- [ ] Performance improvement
- [ ] Chore (dependency updates, tooling changes, etc.)

## Code quality checklist

- [*] **Code style**: Follows project conventions
- [*] **ESLint**: No linting errors
- [*] **Prettier**: Code is properly formatted
- [*] **TypeScript**: Full type coverage
- [*] **Imports**: Uses correct import paths (`@/components/...`)
- [*] **Performance**: No unnecessary re-renders or heavy computations
- [*] **Error handling**: Appropriate error boundaries and validation

