### PR TITLE
Remove `reversed` from activity gauge legends

### DIFF
--- a/components/application/charts/activity-gauges.demo.tsx
+++ b/components/application/charts/activity-gauges.demo.tsx
@@ -101,7 +101,7 @@ export const ActivityGauge = ({ size = "sm", title = "1,000", subtitle = "Active
             >
                 <PolarAngleAxis tick={false} domain={[0, 1000]} type="number" reversed />
 
-                <Legend verticalAlign="bottom" align="center" layout="horizontal" content={<ChartLegendContent reversed />} />
+                <Legend verticalAlign="bottom" align="center" layout="horizontal" content={<ChartLegendContent />} />
 
                 <Tooltip content={<ChartTooltipContent isRadialChart />} />
 


### PR DESCRIPTION
## Description

It seems like Recharts has changed how they sort the legends items in their recent 3rd version. So now the `reversed` prop we were using is not behaving as it was before so we just removed it which fixed the issue.

## Type of change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Style/UI change (visual improvements, no functional changes)
- [ ] Accessibility improvement
- [ ] Refactoring (code changes that neither fix a bug nor add a feature)
- [ ] Performance improvement
- [ ] Chore (dependency updates, tooling changes, etc.)

## Code quality checklist

- [x] **Code style**: Follows project conventions
- [x] **ESLint**: No linting errors
- [x] **Prettier**: Code is properly formatted
- [x] **TypeScript**: Full type coverage
- [x] **Imports**: Uses correct import paths (`@/components/...`)
- [x] **Performance**: No unnecessary re-renders or heavy computations
- [x] **Error handling**: Appropriate error boundaries and validation