### PR TITLE
fix: open popover on input mousedown when focused

### DIFF
--- a/components/base/select/combobox.tsx
+++ b/components/base/select/combobox.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { FocusEventHandler, PointerEventHandler, RefAttributes, RefObject } from "react";
+import type { FocusEventHandler, MouseEventHandler, PointerEventHandler, RefAttributes, RefObject } from "react";
 import { useCallback, useContext, useRef, useState } from "react";
 import { SearchLg as SearchIcon } from "@untitledui/icons";
 import type { ComboBoxProps as AriaComboBoxProps, GroupProps as AriaGroupProps, ListBoxProps as AriaListBoxProps } from "react-aria-components";
@@ -39,6 +39,12 @@ const ComboBoxValue = ({ size, shortcut, placeholder, shortcutClassName, ...othe
     const first = inputValue?.split(value?.supportingText)?.[0] || "";
     const last = inputValue?.split(first)[1];
 
+    const handleInputMouseDown: MouseEventHandler<HTMLInputElement> = () => {
+        if (state && !state.isOpen) {
+            state.open();
+        }
+    };
+
     return (
         <AriaGroup
             {...otherProps}
@@ -65,6 +71,7 @@ const ComboBoxValue = ({ size, shortcut, placeholder, shortcutClassName, ...othe
 
                         <AriaInput
                             placeholder={placeholder}
+                            onMouseDown={handleInputMouseDown}
                             className="z-10 w-full appearance-none bg-transparent text-md text-transparent caret-alpha-black/90 placeholder:text-placeholder focus:outline-hidden disabled:cursor-not-allowed disabled:text-disabled disabled:placeholder:text-disabled"
                         />
                     </div>


### PR DESCRIPTION
## Changes

- Added a mouse-down handler to `Select.ComboBox`'s input so clicking the already-focused field reopens the popover, mirroring the behavior already implemented for the multi-select version.
- This change is needed because after selecting an item, the next click on the still-focused input failed to reopen the menu, preventing immediate reselection.

## Testing

- [x] Tested in Storybook
- [x] Keyboard navigation works
- [x] Screen reader compatible
- [x] Mobile responsive
- [ ] TypeScript compiles *(fails: existing `tsc` run errors in date-picker files unrelated to this change)*
- [x] No lint errors

## Screenshots

Not applicable for this behavioral fix.

## Related issues

Closes #[150](https://github.com/untitleduico/react/issues/150)


