### PR TITLE
Fix ambiguity in button prop types

### DIFF
--- a/components/application/date-picker/range-calendar.tsx
+++ b/components/application/date-picker/range-calendar.tsx
@@ -16,6 +16,7 @@ import {
     RangeCalendarStateContext,
     useSlottedContext,
 } from "react-aria-components";
+import type { ButtonProps } from "@/components/base/buttons/button";
 import { Button } from "@/components/base/buttons/button";
 import { InputDateBase } from "@/components/base/input/input-date";
 import { useBreakpoint } from "@/hooks/use-breakpoint";
@@ -71,7 +72,11 @@ export const RangePresetButton = ({ value, className, children, ...props }: Rang
     );
 };
 
-const MobilePresetButton = ({ value, children, ...props }: HTMLAttributes<HTMLButtonElement> & { value: { start: DateValue; end: DateValue } }) => {
+interface MobilePresetButtonProps extends Omit<ButtonProps, "value" | "slot" | "size" | "color" | "onClick"> {
+    value: { start: DateValue; end: DateValue };
+}
+
+const MobilePresetButton = ({ value, children, ...props }: MobilePresetButtonProps) => {
     const context = useContext(RangeCalendarStateContext);
 
     return (

--- a/components/base/buttons/button.tsx
+++ b/components/base/buttons/button.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { AnchorHTMLAttributes, ButtonHTMLAttributes, DetailedHTMLProps, FC, ReactNode } from "react";
+import type { FC, ReactElement, ReactNode } from "react";
 import React, { isValidElement } from "react";
 import type { ButtonProps as AriaButtonProps, LinkProps as AriaLinkProps } from "react-aria-components";
 import { Button as AriaButton, Link as AriaLink } from "react-aria-components";
@@ -150,28 +150,29 @@ export interface CommonProps {
     noTextPadding?: boolean;
     /** When true, keeps the text visible during loading state */
     showTextWhileLoading?: boolean;
+
+    children?: ReactNode;
+    className?: string;
 }
 
 /**
  * Props for the button variant (non-link)
  */
-export interface ButtonProps extends CommonProps, DetailedHTMLProps<Omit<ButtonHTMLAttributes<HTMLButtonElement>, "color" | "slot">, HTMLButtonElement> {
-    /** Slot name for react-aria component */
-    slot?: AriaButtonProps["slot"];
-}
-
+export interface ButtonProps extends CommonProps, Omit<AriaButtonProps, "children" | "className"> {}
 /**
  * Props for the link variant (anchor tag)
  */
-interface LinkProps extends CommonProps, DetailedHTMLProps<Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "color">, HTMLAnchorElement> {
-    /** Options for the configured client side router. */
-    routerOptions?: AriaLinkProps["routerOptions"];
+interface LinkProps extends CommonProps, Omit<AriaLinkProps, "children" | "className"> {
+    href: NonNullable<AriaLinkProps["href"]>;
 }
 
 /** Union type of button and link props */
 export type Props = ButtonProps | LinkProps;
 
-export const Button = ({
+export const Button: {
+    (props: LinkProps): ReactElement<LinkProps>;
+    (props: ButtonProps): ReactElement<ButtonProps>;
+} = ({
     size = "sm",
     color = "primary",
     children,
@@ -182,50 +183,17 @@ export const Button = ({
     isDisabled: disabled,
     isLoading: loading,
     showTextWhileLoading,
-    ...otherProps
-}: Props) => {
-    const href = "href" in otherProps ? otherProps.href : undefined;
-    const Component = href ? AriaLink : AriaButton;
+    ...props
+}) => {
+    const href = "href" in props ? props.href : undefined;
 
     const isIcon = (IconLeading || IconTrailing) && !children;
     const isLinkType = ["link-gray", "link-color", "link-destructive"].includes(color);
 
     noTextPadding = isLinkType || noTextPadding;
 
-    let props = {};
-
-    if (href) {
-        props = {
-            ...otherProps,
-
-            href: disabled ? undefined : href,
-        };
-    } else {
-        props = {
-            ...otherProps,
-
-            type: otherProps.type || "button",
-            isPending: loading,
-        };
-    }
-
-    return (
-        <Component
-            data-loading={loading ? true : undefined}
-            data-icon-only={isIcon ? true : undefined}
-            {...props}
-            isDisabled={disabled}
-            className={cx(
-                styles.common.root,
-                styles.sizes[size].root,
-                styles.colors[color].root,
-                isLinkType && styles.sizes[size].linkRoot,
-                (loading || (href && (disabled || loading))) && "pointer-events-none",
-                // If in `loading` state, hide everything except the loading icon (and text if `showTextWhileLoading` is true).
-                loading && (showTextWhileLoading ? "[&>*:not([data-icon=loading]):not([data-text])]:hidden" : "[&>*:not([data-icon=loading])]:invisible"),
-                className,
-            )}
-        >
+    const commonChildren = (
+        <>
             {/* Leading icon */}
             {isValidElement(IconLeading) && IconLeading}
             {isReactComponent(IconLeading) && <IconLeading data-icon="leading" className={styles.common.icon} />}
@@ -262,6 +230,30 @@ export const Button = ({
             {/* Trailing icon */}
             {isValidElement(IconTrailing) && IconTrailing}
             {isReactComponent(IconTrailing) && <IconTrailing data-icon="trailing" className={styles.common.icon} />}
-        </Component>
+        </>
     );
+
+    const commonProps = {
+        "data-loading": loading ? true : undefined,
+        "data-icon-only": isIcon ? true : undefined,
+        ...props,
+        isDisabled: disabled,
+        className: cx(
+            styles.common.root,
+            styles.sizes[size].root,
+            styles.colors[color].root,
+            isLinkType && styles.sizes[size].linkRoot,
+            (loading || (href && (disabled || loading))) && "pointer-events-none",
+            // If in `loading` state, hide everything except the loading icon (and text if `showTextWhileLoading` is true).
+            loading && (showTextWhileLoading ? "[&>*:not([data-icon=loading]):not([data-text])]:hidden" : "[&>*:not([data-icon=loading])]:invisible"),
+            className,
+        ),
+        children: commonChildren,
+    };
+
+    if ("href" in commonProps) {
+        return <AriaLink {...commonProps} href={disabled ? undefined : href} />;
+    }
+
+    return <AriaButton {...commonProps} type={commonProps.type || "button"} isPending={loading} />;
 };


### PR DESCRIPTION
## Description

1. Changes `Button` input props types to match the `AriaButtonProps` and `AriaLinkProps` that the button actually passes down to the react aria button and link components internally. This inconsistency was causing me type issues when editing the component to intercept and wrap an `onClick` with a callback.
2. Dynamically provides type feedback to consumer based on whether an `href` prop is passed to the button. Buttons with an `href` prop expect `LinkProps`, and without expect `ButtonProps`.
3. Fixes ambiguous types, such as the event for `onClick` being of `any` type.
4. Fixes non-strict typing of the internal `props` variable. The type for this stayed `{}` even though it was reassigned to contain the rest of the component's props. So anything could be passed to the internal react aria components, without any type checking.
5. Adds an overload signature, and does all the unique logic for each type at the end, in a branching if statement.

The goal here being to increase type interface consistency with the internal react-aria implementation and to fix ambiguous typing. This should not meaningfully change any actual logic, just the types.

## Related issues

None

Closes # None

## Type of change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Style/UI change (visual improvements, no functional changes)
- [ ] Accessibility improvement
- [ ] Refactoring (code changes that neither fix a bug nor add a feature)
- [ ] Performance improvement
- [ ] Chore (dependency updates, tooling changes, etc.)

## Testing

1. Typescript check passes.
2. All storybook components look good.
3. Things like `data-loading` and `data-icon-only` labels are still working.
4. Callbacks like `onClick` show proper event type, such as `MouseEvent<HTMLButtonElement, MouseEvent>` instead of `any`.
5. Link exclusive `href` prop is not allowed while Button exclusive `name` prop is present.
6. Type annotations dynamically change depending on presence of the `href` prop, such as the `onMouseDown` event showing it's type as `MouseEvent<HTMLButtonElement, MouseEvent>` without the `href` prop, but `MouseEvent<HTMLAnchorElement, MouseEvent>` with it. 

### Testing checklist

- [x] **Functionality**: Component works as expected
- [x] **TypeScript**: No TypeScript errors
- [x] **Storybook**: Stories render correctly
- [ ] **Accessibility**:
    - [x] Keyboard navigation works
    - [ ] Screen reader compatible
    - [ ] Focus management is correct
    - [ ] Color contrast meets WCAG AA standards
- [x] **Responsive**: Works on mobile, tablet, and desktop
- [x] **Browser testing**: Tested in multiple browsers
- [x] **Performance**: No performance regressions

(I don't think the change requires the testing that is unchecked)

### Manual testing steps

1. Run type check
2. Check all storybook variants and components
3. Make sure things like `data-loading` and `data-icon-only` show up on the right components.
4. Create a button without an href
5. Check that the `onClick` event type shows `MouseEvent<FocusableElement, MouseEvent>`
6. Check that other general props work
7. Check that the `onMouseDown` event type shows `MouseEvent<HTMLButtonElement, MouseEvent>`.
8. Check that adding a `name` doesn't raise a TS error
9. Add an href
10. Check that the `onClick` event type shows `MouseEvent<FocusableElement, MouseEvent>`
11. Check that other general props work
12. Check that the `onMouseDown` event type shows `MouseEvent<HTMLButtonElement, MouseEvent>`.
13. Check that adding a `name` raises a TS error

## Screenshots/Videos

### Before
<img width="773" height="108" alt="image" src="https://github.com/user-attachments/assets/3b08cff2-fdb3-4d6e-92bb-b27f9e36a77a" />

https://github.com/user-attachments/assets/1307ff4f-4999-4f8c-a0fb-e86fa74968af

### After
<img width="445" height="131" alt="image" src="https://github.com/user-attachments/assets/f73d9fd5-52b4-4cc6-b429-f4afb03c8424" />

https://github.com/user-attachments/assets/08b6f9c5-2f4e-4929-83bb-5f48d9259a7f


## Code quality checklist

- [x] **Code style**: Follows project conventions
- [x] **ESLint**: No linting errors
- [x] **Prettier**: Code is properly formatted
- [x] **TypeScript**: Full type coverage
- [x] **Imports**: Uses correct import paths (`@/components/...`)
- [x] **Performance**: No unnecessary re-renders or heavy computations
- [x] **Error handling**: Appropriate error boundaries and validation

## 📚 Documentation

- [x] Component props are documented with TypeScript interfaces
- [x] Storybook stories cover all variants
- [ ] Usage examples are provided

## Breaking changes

This may cause typescript issues in existing code. For example, the `onClick` callback event is no longer `any` and is now `MouseEvent<FocusableElement, MouseEvent>`.  If you have an `href` prop, you cannot also have a `name` prop, as `href` is mutually exclusive to the anchor tag, and `name` is mutually exclusive to the button tag.

These surfaced type errors indicate real issues in a code base, and should be simple to resolve. Worst case, the consumer of this component can always ignore the type error, since these changes *should be* purely type based.

## Edit:

I've discovered after initially writing this PR, that `onPress` does not work with typescript without this fix, since we're not exposing react-aria props. This prop is the recommended way to use buttons, as listed in their button [documentation](https://react-aria.adobe.com/Button#events) and detailed in their [blog post](https://react-aria.adobe.com/blog/building-a-button-part-1).

This seems like a pretty crucial part to support given that this library heavily advertises that it's built on react-aria.