### PR TITLE
fix: correct app-store-badge-border CSS variable typo in dark mode

### DIFF
--- a/styles/theme.css
+++ b/styles/theme.css
@@ -715,7 +715,7 @@
         --color-bg-primary-solid: var(--color-bg-secondary);
         --color-bg-error-solid_hover: var(--color-red-500);
 
-        --color-app-store-badg-border: var(--color-white);
+        --color-app-store-badge-border: var(--color-white);
         --color-avatar-styles-bg-neutral: 224 224 224 1;
         --color-featured-icon-light-fg-brand: var(--color-brand-200);
         --color-featured-icon-light-fg-error: var(--color-red-200);


### PR DESCRIPTION
## Changes

- Renamed `--color-app-store-badg-border` to `--color-app-store-badge-border` in the dark mode theme block (`styles/theme.css`, line 718)
- Aligns the dark mode override with the light-mode token (line 362) and the `ring-app-store-badge-border` utility used by app store buttons

## Testing

- [x] Tested in Storybook (app store buttons — border in dark mode)
- [x] N/A — keyboard navigation (token-only change)
- [x] N/A — screen reader (token-only change)
- [x] N/A — mobile responsive (token-only change)
- [x] TypeScript compiles (CSS-only change)
- [x] No lint errors (single-line rename)

## Screenshots

before:
<img width="748" height="336" alt="image" src="https://github.com/user-attachments/assets/5f62b920-2ebe-4468-b374-b4fe78661fd3" />

after:
<img width="748" height="336" alt="image" src="https://github.com/user-attachments/assets/d1b91070-1e71-4209-8957-c58404a2d312" />


## Related issues

N/A