### PR TITLE
Support React Aria props in ButtonUtility and SocialButton

### DIFF
--- a/components/base/buttons/button-utility.tsx
+++ b/components/base/buttons/button-utility.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { AnchorHTMLAttributes, ButtonHTMLAttributes, DetailedHTMLProps, FC, ReactNode } from "react";
+import type { FC, ReactElement, ReactNode, RefAttributes } from "react";
 import { isValidElement } from "react";
 import type { Placement } from "react-aria";
 import type { ButtonProps as AriaButtonProps, LinkProps as AriaLinkProps } from "react-aria-components";
@@ -31,81 +31,67 @@ export interface CommonProps {
     tooltip?: string;
     /** The placement of the tooltip */
     tooltipPlacement?: Placement;
+
+    className?: string;
 }
 
 /**
  * Props for the button variant (non-link)
  */
-export interface ButtonProps extends CommonProps, DetailedHTMLProps<Omit<ButtonHTMLAttributes<HTMLButtonElement>, "color" | "slot">, HTMLButtonElement> {
-    /** Slot name for react-aria component */
-    slot?: AriaButtonProps["slot"];
-}
+export interface ButtonProps extends CommonProps, Omit<AriaButtonProps, "children" | "className">, RefAttributes<HTMLButtonElement> {}
 
 /**
  * Props for the link variant (anchor tag)
  */
-interface LinkProps extends CommonProps, DetailedHTMLProps<Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "color">, HTMLAnchorElement> {
-    /** Options for the configured client side router. */
-    routerOptions?: AriaLinkProps["routerOptions"];
+interface LinkProps extends CommonProps, Omit<AriaLinkProps, "children" | "className">, RefAttributes<HTMLAnchorElement> {
+    /** The link target. Required as a key to select the link variant, but may be `undefined` (e.g. a disabled nav button). */
+    href: AriaLinkProps["href"];
 }
 
 /** Union type of button and link props */
 export type Props = ButtonProps | LinkProps;
 
-export const ButtonUtility = ({
-    tooltip,
-    className,
-    isDisabled,
-    icon: Icon,
-    size = "sm",
-    color = "secondary",
-    tooltipPlacement = "top",
-    ...otherProps
-}: Props) => {
-    const href = "href" in otherProps ? otherProps.href : undefined;
-    const Component = href ? AriaLink : AriaButton;
+export const ButtonUtility: {
+    (props: LinkProps): ReactElement<LinkProps>;
+    (props: ButtonProps): ReactElement<ButtonProps>;
+} = ({ tooltip, className, isDisabled, icon: Icon, size = "sm", color = "secondary", tooltipPlacement = "top", ...props }) => {
+    const commonProps = {
+        "aria-label": tooltip,
+        ...props,
+        isDisabled,
+        className: cx(
+            "group relative inline-flex h-max cursor-pointer items-center justify-center rounded-md p-1.5 outline-focus-ring transition duration-100 ease-linear focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+            styles[color],
 
-    let props = {};
+            // Icon styles
+            "*:data-icon:pointer-events-none *:data-icon:shrink-0 *:data-icon:text-current *:data-icon:transition-inherit-all",
+            size === "xs" ? "*:data-icon:size-4" : "*:data-icon:size-5",
 
-    if (href) {
-        props = {
-            ...otherProps,
+            className,
+        ),
+        children: (
+            <>
+                {isReactComponent(Icon) && <Icon data-icon />}
+                {isValidElement(Icon) && Icon}
+            </>
+        ),
+    };
 
-            href: isDisabled ? undefined : href,
+    let content: ReactElement;
 
-            // Since anchor elements do not support the `disabled` attribute and state,
-            // we need to specify `data-rac` and `data-disabled` in order to be able
-            // to use the `disabled:` selector in classes.
-            ...(isDisabled ? { "data-rac": true, "data-disabled": true } : {}),
-        };
+    if ("href" in commonProps) {
+        const { href: linkHref, ...rest } = commonProps;
+
+        // An explicitly `undefined` href (e.g. a disabled prev/next control) renders a
+        // real <button> rather than React Aria's link fallback <span>.
+        content = linkHref ? (
+            <AriaLink {...commonProps} href={isDisabled ? undefined : linkHref} />
+        ) : (
+            <AriaButton {...(rest as AriaButtonProps)} type="button" />
+        );
     } else {
-        props = {
-            ...otherProps,
-
-            type: otherProps.type || "button",
-            isDisabled,
-        };
+        content = <AriaButton {...commonProps} type={commonProps.type || "button"} />;
     }
-
-    const content = (
-        <Component
-            aria-label={tooltip}
-            {...props}
-            className={cx(
-                "group relative inline-flex h-max cursor-pointer items-center justify-center rounded-md p-1.5 outline-focus-ring transition duration-100 ease-linear focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
-                styles[color],
-
-                // Icon styles
-                "*:data-icon:pointer-events-none *:data-icon:shrink-0 *:data-icon:text-current *:data-icon:transition-inherit-all",
-                size === "xs" ? "*:data-icon:size-4" : "*:data-icon:size-5",
-
-                className,
-            )}
-        >
-            {isReactComponent(Icon) && <Icon data-icon />}
-            {isValidElement(Icon) && Icon}
-        </Component>
-    );
 
     if (tooltip) {
         return (

--- a/components/base/buttons/social-button.tsx
+++ b/components/base/buttons/social-button.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { AnchorHTMLAttributes, ButtonHTMLAttributes, DetailedHTMLProps } from "react";
+import type { ReactElement, ReactNode, RefAttributes } from "react";
 import type { ButtonProps as AriaButtonProps, LinkProps as AriaLinkProps } from "react-aria-components";
 import { Button as AriaButton, Link as AriaLink } from "react-aria-components";
 import { cx, sortCx } from "@/utils/cx";
@@ -47,25 +47,35 @@ export const styles = sortCx({
 
 interface CommonProps {
     social: "google" | "facebook" | "apple" | "twitter" | "figma" | "dribble";
+    /** Disables the button and shows a disabled state */
+    isDisabled?: boolean;
+    /**
+     * Disables the button and shows a disabled state.
+     * @deprecated Use `isDisabled` instead, for consistency with `Button` and React Aria.
+     */
     disabled?: boolean;
     theme?: "brand" | "color" | "gray";
     size?: keyof typeof styles.sizes;
+
+    children?: ReactNode;
+    className?: string;
 }
 
-interface ButtonProps extends CommonProps, DetailedHTMLProps<Omit<ButtonHTMLAttributes<HTMLButtonElement>, "color" | "slot">, HTMLButtonElement> {
-    slot?: AriaButtonProps["slot"];
-}
+interface ButtonProps extends CommonProps, Omit<AriaButtonProps, "children" | "className">, RefAttributes<HTMLButtonElement> {}
 
-interface LinkProps extends CommonProps, DetailedHTMLProps<Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "color">, HTMLAnchorElement> {
-    /** Options for the configured client side router. */
-    routerOptions?: AriaLinkProps["routerOptions"];
+interface LinkProps extends CommonProps, Omit<AriaLinkProps, "children" | "className">, RefAttributes<HTMLAnchorElement> {
+    /** The link target. Required as a key to select the link variant, but may be `undefined` (e.g. a disabled nav button). */
+    href: AriaLinkProps["href"];
 }
 
 export type SocialButtonProps = ButtonProps | LinkProps;
 
-export const SocialButton = ({ size = "lg", theme = "brand", social, className, children, disabled, ...otherProps }: SocialButtonProps) => {
-    const href = "href" in otherProps ? otherProps.href : undefined;
-    const Component = href ? AriaLink : AriaButton;
+export const SocialButton: {
+    (props: LinkProps): ReactElement<LinkProps>;
+    (props: ButtonProps): ReactElement<ButtonProps>;
+} = ({ size = "lg", theme = "brand", social, className, children, isDisabled, disabled, ...props }) => {
+    // `disabled` is the deprecated alias of `isDisabled`.
+    const isButtonDisabled = isDisabled ?? disabled;
 
     const isIconOnly = !children;
 
@@ -91,35 +101,8 @@ export const SocialButton = ({ size = "lg", theme = "brand", social, className, 
 
     const Logo = logos[social];
 
-    let props = {};
-
-    if (href) {
-        props = {
-            ...otherProps,
-
-            href: disabled ? undefined : href,
-
-            // Since anchor elements do not support the `disabled` attribute and state,
-            // we need to specify `data-rac` and `data-disabled` in order to be able
-            // to use the `disabled:` selector in classes.
-            ...(disabled ? { "data-rac": true, "data-disabled": true } : {}),
-        };
-    } else {
-        props = {
-            ...otherProps,
-
-            type: otherProps.type || "button",
-            isDisabled: disabled,
-        };
-    }
-
-    return (
-        <Component
-            isDisabled={disabled}
-            {...props}
-            data-icon-only={isIconOnly ? true : undefined}
-            className={cx(styles.common.root, styles.sizes[size].root, colorStyles.root, className)}
-        >
+    const commonChildren = (
+        <>
             <Logo
                 className={cx(
                     styles.common.icon,
@@ -140,6 +123,28 @@ export const SocialButton = ({ size = "lg", theme = "brand", social, className, 
             />
 
             {children}
-        </Component>
+        </>
     );
+
+    const commonProps = {
+        "data-icon-only": isIconOnly ? true : undefined,
+        ...props,
+        isDisabled: isButtonDisabled,
+        className: cx(styles.common.root, styles.sizes[size].root, colorStyles.root, className),
+        children: commonChildren,
+    };
+
+    if ("href" in commonProps) {
+        const { href: linkHref, ...rest } = commonProps;
+
+        // An explicitly `undefined` href renders a real <button> rather than React Aria's
+        // link fallback <span>.
+        return linkHref ? (
+            <AriaLink {...commonProps} href={isButtonDisabled ? undefined : linkHref} />
+        ) : (
+            <AriaButton {...(rest as AriaButtonProps)} type="button" />
+        );
+    }
+
+    return <AriaButton {...commonProps} type={commonProps.type || "button"} />;
 };


### PR DESCRIPTION
## Description

`ButtonUtility` and `SocialButton` both render React Aria's `Button`/`Link` under the hood, but typed their props as raw DOM attributes (`DetailedHTMLProps<ButtonHTMLAttributes<...>>`). As a result `onPress` — the way React Aria expects buttons to handle activation — was a TypeScript error on both, even though it worked at runtime.

This applies the same treatment #183 gave to `Button`:

- **Props now build on `AriaButtonProps`/`AriaLinkProps`.** This adds `onPress` plus the rest of the React Aria surface (`onPressStart`, `onHoverStart`, `excludeFromTabOrder`, …). The hand-written `slot` and `routerOptions` escape hatches are gone — they come from the Aria props now.
- **Removed the untyped `let props = {}`.** It was reassigned but never re-typed, so anything spread into the React Aria component was unchecked (defect 4 in #183, which was fixed in `Button` but left in these two). Replaced with a single typed `commonProps` object plus an overload signature.
- **`SocialButton` gains `isDisabled`**, matching `Button`, `ButtonUtility`, and React Aria. `disabled` still works as a `@deprecated` alias, so the ~40 existing login/signup usages are unaffected.
- **`RefAttributes` kept on both variants**, so `ref` continues to type-check (it works at runtime via the props spread — see "Additional context").

Behavior is unchanged. In particular, an `href` prop that is present but `undefined` (the disabled prev/next nav pattern) still renders a real `<button>` rather than React Aria's link fallback `<span>`.

## Related issues

Closes #191

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Style/UI change (visual improvements, no functional changes)
- [ ] Accessibility improvement
- [ ] Refactoring (code changes that neither fix a bug nor add a feature)
- [ ] Performance improvement
- [ ] Chore (dependency updates, tooling changes, etc.)

Source-breaking only — no runtime behavior changes. See "Breaking changes" below.

## Testing

**Type-level.** A generated prop matrix compiled `onPress` and 28 other props against all four RAC-based button components. `onPress` now type-checks on `Button`, `ButtonUtility`, `SocialButton`, and `CloseButton`, in both button and link variants. Negative cases confirm the discriminated union still holds: `type="submit"` on a link variant, `target` on a button variant, and unknown props are all still rejected.

**Behavioral.** SSR render tests over both components:

| Case | Result |
|---|---|
| `<ButtonUtility icon={X} />` | `<button type="button">` |
| `<ButtonUtility icon={X} href="/x" />` | `<a href="/x">` |
| `<ButtonUtility icon={X} href={undefined} isDisabled />` | `<button>` (not `<span>`) |
| `<ButtonUtility icon={X} href="/x" isDisabled />` | `<span data-rac data-disabled>` |
| `<ButtonUtility icon={X} tooltip="Close" />` | `aria-label="Close"` |
| `<SocialButton social="google" disabled />` / `isDisabled` | both disable identically |
| `<SocialButton social="google">Sign in</SocialButton>` | no `data-icon-only` attribute |

**Regression surface.** Root `tsc --noEmit` across the full app — ~110 `private-components` usages plus the docs app — returns a byte-identical error set to the pre-change baseline. Zero new errors.

### Testing checklist

- [x] **Functionality**: Component works as expected
- [x] **TypeScript**: No TypeScript errors
- [ ] **Storybook**: Stories render correctly *(stories type-check; not opened in a browser)*
- [ ] **Accessibility**:
    - [ ] Keyboard navigation works *(not manually re-tested; `onPress` support is what #191 flags as the a11y impact)*
    - [ ] Screen reader compatible
    - [ ] Focus management is correct
    - [ ] Color contrast meets WCAG AA standards
- [ ] **Responsive**: Works on mobile, tablet, and desktop *(no style changes)*
- [ ] **Browser testing**: Tested in multiple browsers *(SSR output verified instead)*
- [ ] **Performance**: No performance regressions *(not measured; one fewer object allocation per render)*

Unchecked boxes are things I did not verify, not things I'm asserting.

### Manual testing steps

1. `<ButtonUtility icon={X} onPress={() => {}} />` — compiles, fires on click and on Enter/Space.
2. `<SocialButton social="google" onPress={() => {}} />` — same.
3. `<ButtonUtility icon={ArrowLeft} href={maybeUndefinedHref} isDisabled={!maybeUndefinedHref} />` — renders a disabled `<button>`, styled identically to before.
4. `<SocialButton social="google" disabled />` — still disabled; check the `@deprecated` hint appears in your editor.
5. `<ButtonUtility icon={X} title="Delete" />` — now a compile error. Confirm `title` never reached the DOM before this change (see below).

## Screenshots/Videos

No visual change — this PR is types plus an internal refactor. The SSR markup table above is the closest equivalent; disabled-link styling still resolves because React Aria emits `data-rac` and `data-disabled` itself.

## Code quality checklist

- [x] **Code style**: Follows project conventions
- [x] **ESLint**: No linting errors
- [x] **Prettier**: Code is properly formatted
- [x] **TypeScript**: Full type coverage
- [x] **Imports**: Uses correct import paths (`@/components/...`)
- [x] **Performance**: No unnecessary re-renders or heavy computations
- [x] **Error handling**: Appropriate error boundaries and validation

## 📚 Documentation

- [x] Component props are documented with TypeScript interfaces
- [ ] Storybook stories cover all variants *(existing stories unchanged and still compile)*
- [ ] Usage examples are provided

## Breaking changes

Same category as #183 was for `Button`: **source-breaking, behavior-neutral.**

Switching from `ButtonHTMLAttributes`/`AnchorHTMLAttributes` to the React Aria prop types removes 145 DOM props from the accepted surface of these two components. The important thing is that **React Aria already stripped every one of them at runtime** — `RAC.Button` ends with `filterDOMProps(props, { global: true })`, an allowlist. I confirmed `onMouseDown`, `onPointerDown`, and `onClick` are in it while `title`, `role`, `tabIndex`, `onDragStart`, and `onCopy` are not, and rendering with `title`/`role`/`tabIndex` produces none of them in the HTML.

So the old types advertised props the components never delivered. Code passing them was already broken; it now fails at compile time instead of silently doing nothing.

What is removed:

- `title`, `role`, `tabIndex`, `disabled`, plus microdata/RDFa/legacy attributes
- media, form, clipboard, drag, and composition events (`onChange`, `onSubmit`, `onCopy`, `onDragStart`, `onCanPlay`, …)
- `*Capture` variants of the focus/keyboard events

What is retained: `onClick`, `onMouseDown`, `onMouseEnter`, `onFocus`, `onBlur`, `onKeyDown`, `id`, `style`, `className`, and all `aria-*` / `data-*` attributes (TypeScript does not check hyphenated JSX attributes against the props type, so those are unaffected).

### Migration guide

```tsx
// Before — `title` compiled but never reached the DOM, so no tooltip appeared
<ButtonUtility icon={Trash01} title="Delete" />

// After — use the `tooltip` prop, which actually renders one
<ButtonUtility icon={Trash01} tooltip="Delete" />
```

```tsx
// Before — still works, now marked @deprecated
<SocialButton social="google" disabled />

// After — consistent with Button, ButtonUtility, and React Aria
<SocialButton social="google" isDisabled />
```

For `role` / `tabIndex`, there is no replacement prop, because they never took effect. React Aria manages both.

## Additional context

**`href` typing differs from `Button` on purpose.** `Button`'s link variant requires `href: NonNullable<...>`. I tried that here first and it produced 6 new type errors in the docs app, all the prev/next nav pattern `href={maybeUndefined} isDisabled={!href}`. Requiring a non-null href would be a genuine breaking change for that pattern, so the link variant here keeps `href` as a **required key with a nullable value** — enough to discriminate the union, permissive enough for real code. Worth considering the same relaxation for `Button` in a follow-up; it would be strictly more permissive and therefore non-breaking.

**Out of scope, but found while verifying:** `ref` is currently rejected by `Button`'s types. It worked through v8.0 via `DetailedHTMLProps` (which includes `RefAttributes`) and was dropped by #183, since React Aria declares `ref` on the exported component rather than inside `ButtonProps`. `CloseButton` never had it. Both still work at runtime. The fix is one line each — adding `RefAttributes<HTMLButtonElement>` / `RefAttributes<HTMLAnchorElement>` — but it is deliberately not included here to keep this PR scoped to #191.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0183piBZMscJ3jaj7EBVnLSB
